### PR TITLE
Updated term list parser to handle some (silly) HTML changes by MyPurdue

### DIFF
--- a/CatalogApi/Parsers/TermListParser.cs
+++ b/CatalogApi/Parsers/TermListParser.cs
@@ -16,7 +16,7 @@ namespace CatalogApi.Parsers
 			HtmlDocument document = new HtmlDocument();
 			document.LoadHtml(content);
 			HtmlNode root = document.DocumentNode;
-			HtmlNodeCollection termSelectNodes = root.SelectNodes("//select[@id='term_input_id'][1]/option");
+			HtmlNodeCollection termSelectNodes = root.SelectNodes("//select[@name='p_term']/option");
 			var terms = new List<MyPurdueTerm>();
 			foreach (var node in termSelectNodes)
 			{


### PR DESCRIPTION
Something changed on the MyPurdue side and introduced this fun nugget of invalid HTML:

```html
<select name="p_term" size="1"  BYPASS_ESC=>"Y" ID="term_input_id">
<OPTION VALUE="">None</OPTION>
<OPTION VALUE="201930">Summer 2019</OPTION>
[...]
</select>
```

This change updates the term list parser to handle this HTML.