### PR TITLE
Change build script from 'prepare' to 'build'

### DIFF
--- a/Purdue.io API/package.json
+++ b/Purdue.io API/package.json
@@ -3,7 +3,7 @@
   "name": "purdue-io",
   "private": true,
   "scripts": {
-    "prepare": "webpack --mode=production && lessc Content/css/Demo.less Content/css/style.css"
+    "build": "webpack --mode=production && lessc Content/css/Demo.less Content/css/style.css"
   },
   "devDependencies": {
     "@types/es6-promise": "^3.3.0",


### PR DESCRIPTION
`prepare` runs automatically after `npm install`, which we don't want. So I'm renaming this npm script to `build`.