### PR TITLE
5️⃣ Increase max expansion depth to 5

### DIFF
--- a/src/Api/Controllers/BuildingController.cs
+++ b/src/Api/Controllers/BuildingController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Buildings);

--- a/src/Api/Controllers/CampusController.cs
+++ b/src/Api/Controllers/CampusController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Campuses);

--- a/src/Api/Controllers/ClassController.cs
+++ b/src/Api/Controllers/ClassController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Classes);

--- a/src/Api/Controllers/CourseController.cs
+++ b/src/Api/Controllers/CourseController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Courses);

--- a/src/Api/Controllers/InstructorController.cs
+++ b/src/Api/Controllers/InstructorController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Instructors);

--- a/src/Api/Controllers/MeetingController.cs
+++ b/src/Api/Controllers/MeetingController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Meetings);

--- a/src/Api/Controllers/RoomController.cs
+++ b/src/Api/Controllers/RoomController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Rooms);

--- a/src/Api/Controllers/SectionController.cs
+++ b/src/Api/Controllers/SectionController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Sections);

--- a/src/Api/Controllers/SubjectController.cs
+++ b/src/Api/Controllers/SubjectController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Subjects);

--- a/src/Api/Controllers/TermController.cs
+++ b/src/Api/Controllers/TermController.cs
@@ -16,7 +16,7 @@ namespace PurdueIo.Api.Controllers
         }
 
         [HttpGet]
-        [EnableQuery(MaxExpansionDepth = 3, MaxAnyAllExpressionDepth = 3)]
+        [EnableQuery(MaxExpansionDepth = 5, MaxAnyAllExpressionDepth = 5)]
         public IActionResult Get(CancellationToken token)
         {
             return Ok(dbContext.Terms);


### PR DESCRIPTION
The Purdue.io Browser will require OData expansion depth of 5 for some queries - this change increases the limit to accommodate.