### PR TITLE
📄 Remove page limit due to EF Core query generation bug

### DIFF
--- a/src/Api/EdmModelBuilder.cs
+++ b/src/Api/EdmModelBuilder.cs
@@ -37,7 +37,8 @@ namespace PurdueIo.Api
                 .Count()
                 .Expand(MAX_EXPAND_DEPTH)
                 .OrderBy()
-                .Page(MAX_RESULTS, MAX_RESULTS)
+                // .Page(MAX_RESULTS, MAX_RESULTS) // Pending query gen fix available in .NET 6
+                                                   // https://github.com/dotnet/efcore/issues/24726
                 .Select();
         }
     }


### PR DESCRIPTION
This change removes the limit on query results due to an EF bug https://github.com/dotnet/efcore/issues/24726 . This bug is fixed in .NET 6.

Once .NET 6 is released and we're able to update we can re-introduce paging limits.