### PR TITLE
📊 Exclude test resources from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Exclude test HTML from GitHub's linguist indexing
+# (so it doesn't think our repo is just a giant bunch of HTML)
+src/Tests/Resources/**/* linguist-documentation


### PR DESCRIPTION
We have a bunch of HTML checked in as testing resources - GitHub's "linguist" is picking up this HTML and it's throwing off our language stats. This change adds a git attribute to tell linguist to ignore these files.