### PR TITLE
🕜 Update default sync policy to include future terms

### DIFF
--- a/src/CatalogSync/FastSync.cs
+++ b/src/CatalogSync/FastSync.cs
@@ -148,8 +148,9 @@ namespace PurdueIo.CatalogSync
                 }
                 else if (termSyncBehavior == TermSyncBehavior.SyncNewAndCurrentTerms)
                 {
-                    if ((terms[scrapedTerm.Id].StartDate < DateTimeOffset.Now) &&
-                        (terms[scrapedTerm.Id].EndDate > DateTimeOffset.Now))
+                    // We only care about terms that haven't ended yet - 
+                    // we still want to sync "future" terms.
+                    if (terms[scrapedTerm.Id].EndDate > DateTimeOffset.Now)
                     {
                         termsToSync.Add(terms[scrapedTerm.Id]);
                     }


### PR DESCRIPTION
An oversight in CatalogSync meant that terms that hadn't started yet were not being included in the sync run.

This change updates the selection logic to only exclude terms that ended in the past and _not_ exclude terms that start in the future.