### PR TITLE
✏️ Fix CatalogSync user flag

### DIFF
--- a/src/CatalogSync/Program.cs
+++ b/src/CatalogSync/Program.cs
@@ -58,7 +58,7 @@ namespace PurdueIo.CatalogSync
 
         static async Task RunASync(Options options)
         {
-            string username = options.MyPurduePass ?? 
+            string username = options.MyPurdueUser ?? 
                 Environment.GetEnvironmentVariable("MY_PURDUE_USERNAME");
             string password = options.MyPurduePass ?? 
                 Environment.GetEnvironmentVariable("MY_PURDUE_PASSWORD");


### PR DESCRIPTION
Addresses #51 

Fixes an issue where CatalogSync would incorrectly handle username/password command line flags.