### PR TITLE
🛑 Stop using MyPurdue pages that require auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ there through the query tester at [http://api.purdue.io/](api.purdue.io/).
 
 ## Tools
 
-Purdue.io is written in C# on .NET 5. It will run natively on most major
+Purdue.io is written in C# on .NET 8. It will run natively on most major
 architectures and operating systems (Windows, Linux, Mac OS).
 
 Entity Framework is used to communicate with an underlying database provider. Currently,
@@ -71,10 +71,7 @@ To start developing locally, install the .NET SDK.
 CatalogSync is the process used to pull course data from MyPurdue and synchronize it to a
 relational database store.
 
-In order to access detailed course section information, CatalogSync requires a valid
-MyPurdue username and password.
-
-CatalogSync also accepts options to configure which database provider and connection it uses.
+CatalogSync accepts options to configure which database provider and connection it uses.
 
 Additional flags are available to configure CatalogSync behavior. 
 Use the `--help` flag for more information.
@@ -83,10 +80,10 @@ Use the `--help` flag for more information.
 cd src/CatalogSync
 
 # To sync to default SQLite file purdueio.sqlite
-dotnet run -- -u USERNAME -p PASSWORD
+dotnet run
 
 # To sync to a specific SQLite file
-dotnet run -- -u USERNAME -p PASSWORD -d Sqlite -c "Data Source=path/to/file.sqlite"
+dotnet run -- -d Sqlite -c "Data Source=path/to/file.sqlite"
 ```
 
 CatalogSync will begin synchronizing course catalog data to `purdueio.sqlite`.
@@ -96,7 +93,7 @@ and connection string:
 
 ```sh
 # To sync to a local PostgreSQL instance:
-dotnet run -- -u USERNAME -p PASSWORD -d Npgsql -c "Host=localhost;Database=purdueio;Username=purdueio;Password=purdueio"
+dotnet run -- -d Npgsql -c "Host=localhost;Database=purdueio;Username=purdueio;Password=purdueio"
 ```
 
 ## API

--- a/src/CatalogSync/Program.cs
+++ b/src/CatalogSync/Program.cs
@@ -21,12 +21,6 @@ namespace PurdueIo.CatalogSync
 
         public class Options
         {
-            [Option(shortName: 'u', longName: "user", HelpText = "MyPurdue User Name")]
-            public string MyPurdueUser { get; set; }
-
-            [Option(shortName: 'p', longName: "pass", HelpText = "MyPurdue Password")]
-            public string MyPurduePass { get; set; }
-
             [Option(shortName: 'd', longName: "data-provider", Default = DataProvider.Sqlite,
                 HelpText = "The database provider to use")]
             public DataProvider DataProvider { get; set; }
@@ -58,19 +52,6 @@ namespace PurdueIo.CatalogSync
 
         static async Task RunASync(Options options)
         {
-            string username = options.MyPurdueUser ?? 
-                Environment.GetEnvironmentVariable("MY_PURDUE_USERNAME");
-            string password = options.MyPurduePass ?? 
-                Environment.GetEnvironmentVariable("MY_PURDUE_PASSWORD");
-
-            if ((username == null) || (password == null))
-            {
-                Console.Error.WriteLine("You must provide a MyPurdue username and password " +
-                    "to sync course data. Use command line options or environment variables " +
-                    "MY_PURDUE_USERNAME and MY_PURDUE_PASSWORD.");
-                return;
-            }
-
             var loggerFactory = LoggerFactory.Create(b => 
                 b.AddSimpleConsole(c => c.TimestampFormat = "hh:mm:ss.fff "));
 
@@ -85,7 +66,7 @@ namespace PurdueIo.CatalogSync
 
             var behavior = options.SyncAllTerms ? 
                 TermSyncBehavior.SyncAllTerms : TermSyncBehavior.SyncNewAndCurrentTerms;
-            var connection = await MyPurdueConnection.CreateAndConnectAsync(username, password,
+            var connection = new MyPurdueConnection(
                 loggerFactory.CreateLogger<MyPurdueConnection>());
             var scraper = new MyPurdueScraper(connection,
                 loggerFactory.CreateLogger<MyPurdueScraper>());

--- a/src/Scraper/Connections/IMyPurdueConnection.cs
+++ b/src/Scraper/Connections/IMyPurdueConnection.cs
@@ -14,9 +14,5 @@ namespace PurdueIo.Scraper.Connections
         // Retrieves the contents of bwckschd.p_get_crse_unsec from MyPurdue for the given term
         // and subject
         Task<string> GetSectionListPageAsync(string termCode, string subjectCode);
-
-        // Retrieves the contents of bwskfcls.P_GetCrse_Advanced from MyPurdue for the given term
-        // and subject
-        Task<string> GetSectionDetailsPageAsync(string termCode, string subjectCode);
     }
 }

--- a/src/Tests/ParsingTests.cs
+++ b/src/Tests/ParsingTests.cs
@@ -42,13 +42,21 @@ namespace PurdueIo.Tests
             Assert.Equal("", spotCheck.LinkOther);
             Assert.Equal("PWL", spotCheck.CampusCode);
             Assert.Equal("West Lafayette Campus", spotCheck.CampusName);
-            Assert.Equal(24, spotCheck.Capacity);
-            Assert.Equal(5, spotCheck.Enrolled);
-            Assert.Equal(19, spotCheck.RemainingSpace);
+
+            // The loss of authenticated APIs removed our source of information for 
+            // capacity, enrolled, remaining space, and waitlists without querying
+            // each CRN individually.
+            // So now these are all zero.
+            // Tracked here: https://github.com/Purdue-io/PurdueApi/issues/56
+            Assert.Equal(0, spotCheck.Capacity);
+            Assert.Equal(0, spotCheck.Enrolled);
+            Assert.Equal(0, spotCheck.RemainingSpace);
             Assert.Equal(0, spotCheck.WaitListCapacity);
             Assert.Equal(0, spotCheck.WaitListCount);
             Assert.Equal(0, spotCheck.WaitListSpace);
+            
             Assert.Equal(2, spotCheck.Meetings.Length);
+
             // First meeting
             Meeting spotCheckMeeting = spotCheck.Meetings[0];
             Assert.Equal("Lecture", spotCheckMeeting.Type);


### PR DESCRIPTION
Recent changes to Purdue's authentication processes have made scraping MyPurdue pages that require authorization not feasible.

This change updates the scraping process to avoid these pages and resort to workarounds (such as manually defined data mapping tables) or omitting data entirely (such as enrollment information).

See issues #54, #55, #56 for more information on the changes to available data.