### PR TITLE
Fix top option not working

### DIFF
--- a/src/Api/EdmModelBuilder.cs
+++ b/src/Api/EdmModelBuilder.cs
@@ -37,8 +37,7 @@ namespace PurdueIo.Api
                 .Count()
                 .Expand(MAX_EXPAND_DEPTH)
                 .OrderBy()
-                // .Page(MAX_RESULTS, MAX_RESULTS) // Pending query gen fix available in .NET 6
-                                                   // https://github.com/dotnet/efcore/issues/24726
+                .Page(MAX_RESULTS, MAX_RESULTS)
                 .Select();
         }
     }


### PR DESCRIPTION
Fixes #62
Tested that using $top > 0 works now
I'm assuming `.Page()` should've been uncommented after the issue was fixed in .NET 6?