### PR TITLE
🐌 Fix performance regression causing Purdue.io front-end timeouts

### DIFF
--- a/src/Api/EdmModelBuilder.cs
+++ b/src/Api/EdmModelBuilder.cs
@@ -37,7 +37,9 @@ namespace PurdueIo.Api
                 .Count()
                 .Expand(MAX_EXPAND_DEPTH)
                 .OrderBy()
-                .Page(MAX_RESULTS, MAX_RESULTS)
+                // .Page(MAX_RESULTS, MAX_RESULTS) // Adding pagination introduces performance
+                                                   // problems on expand queries.
+                                                   // https://github.com/OData/AspNetCoreOData/issues/1041
                 .Select();
         }
     }


### PR DESCRIPTION
Recently the Purdue.io front-end started showing timeouts when browsing the Class list page for a particular Course.

Investigation revealed expensive SQL queries being generated, taking upwards of a minute to complete. Analysis revealed this section was contributing most of the cost of the query, requiring sequential evaluation of rows from disk:
```sql
SELECT t8."Id", t8."Email", t8."Name", t8."MeetingId", t8."InstructorId"
FROM (
	SELECT i."Id", i."Email", i."Name", m0."MeetingId", m0."InstructorId", ROW_NUMBER() OVER(PARTITION BY m0."MeetingId" ORDER BY i."Id") AS row
	FROM "MeetingInstructor" AS m0
	INNER JOIN "Instructors" AS i ON m0."InstructorId" = i."Id"
) AS t8
WHERE t8.row <= $7
```

Further investigation revealed that this was due to pagination logic being applied to the `$expand` operation. An issue is open with a similar repro here: https://github.com/OData/AspNetCoreOData/issues/1041

The pagination logic was being applied due to the recent change #65. This PR reverts that change to fix the performance regression until a workaround is provided by the OData library.