### PR TITLE
🏫 Add Columbus Learning Center building

### DIFF
--- a/src/Scraper/MyPurdueScraper.cs
+++ b/src/Scraper/MyPurdueScraper.cs
@@ -620,6 +620,9 @@ namespace PurdueIo.Scraper
                                 // "Informatics and Communications Technology Complex" as above
             { "Science & Engineering Lab", "EL" },
             { "Ezkenazi Hall", "HR" }, // Someone at Purdue must have misspelled "Eskenazi"... 🤦
+
+            // Purdue Polytechnic Columbus
+            { "Columbus Learning Center", "CLC" },
         };
 
         public (string buildingName, string buildingShortCode, string room)? ParseLocationDetails(


### PR DESCRIPTION
Missing building entry was causing a sync failure. This change adds the missing building "Columbus Learning Center" "CLC".