### PR TITLE
🏢 Add Indiana College Network building listing

### DIFF
--- a/src/Scraper/MyPurdueScraper.cs
+++ b/src/Scraper/MyPurdueScraper.cs
@@ -623,6 +623,15 @@ namespace PurdueIo.Scraper
 
             // Purdue Polytechnic Columbus
             { "Columbus Learning Center", "CLC" },
+
+            // Indiana College Network
+            // Course descriptions note:
+            //     "Indiana Partnership for Statewide Education distance course."
+            // Examples:
+            //     Indiana College Network ITCC-BL
+            //     Indiana College Network ITCC-GA
+            //     Indiana College Network VU
+            { "Indiana College Network", "ICN" },
         };
 
         public (string buildingName, string buildingShortCode, string room)? ParseLocationDetails(


### PR DESCRIPTION
A new building started appearing in Summer 2008 term course listings, strangely.

This change adds the building record so synchronization can complete successfully.