### PR TITLE
🐜 Fix syncing Courses with duplicate Number + Title

### DIFF
--- a/src/CatalogSync/FastSync.cs
+++ b/src/CatalogSync/FastSync.cs
@@ -87,8 +87,9 @@ namespace PurdueIo.CatalogSync
         private Dictionary<string, DatabaseCampus> dbCachedCampuses =
             new Dictionary<string, DatabaseCampus>();
 
-        private Dictionary<(string number, string title), DatabaseCourse> dbCachedCourses = 
-            new Dictionary<(string number, string title), DatabaseCourse>();
+        private Dictionary<(string subjectCode, string number, string title), DatabaseCourse>
+            dbCachedCourses = 
+                new Dictionary<(string subjectCode, string number, string title), DatabaseCourse>();
 
         private Dictionary<(Guid campusId, string buildingCode), DatabaseBuilding> dbCachedBuildings
             = new Dictionary<(Guid campusId, string buildingCode), DatabaseBuilding>();
@@ -438,7 +439,8 @@ namespace PurdueIo.CatalogSync
             string courseTitle, double creditHours, string courseDescription)
         {
             DatabaseCourse course;
-            var courseKey = (number: courseNumber, title: courseTitle);
+            var courseKey = (subjectCode: subject.Abbreviation,
+                number: courseNumber, title: courseTitle);
             if (dbCachedCourses.ContainsKey(courseKey))
             {
                 course = dbCachedCourses[courseKey];


### PR DESCRIPTION
A bug was recently discovered where course data was missing for courses that had identical titles and numbers, but different subjects: #76 

As an example instance, in Spring 2025, MyPurdue lists `MA 41600` and `STAT 41600`, both titled "Probability," however Purdue.io only shows `MA 41600` with every CRN from both of the original courses grouped under it.

The root cause is that CatalogSync caches courses indexed only by their number and title, not by their subject. This causes any courses with an identical number and title to be grouped together, even those from different subjects.

This change modifies the index to key off of subject code in addition to number and title, resolving the initial bug.

It also includes the logic needed to "move" classes that were erroneously synced with the existing logic to the correct place.