### PR TITLE
🏛️ Add missing IUI campus entry

### DIFF
--- a/src/Scraper/MyPurdueScraper.cs
+++ b/src/Scraper/MyPurdueScraper.cs
@@ -386,6 +386,7 @@ namespace PurdueIo.Scraper
             // but are still found in section listings
             { "Dual Campus Campus", "TDC" },
             { "Concurrent Credit Campus", "CC" },
+            { "Indiana Univ Indianapolis Campus", "IUI" },
         };
 
         // The loss of authenticated APIs removed our source of information for 


### PR DESCRIPTION
A new campus entry appeared in the `202610` term: `Indiana Univ Indianapolis Campus`. This blocks sync from completing.

The campus doesn't appear in the course catalog search form, so I took a stab at defining my own short code for it: `IUI`.