### PR TITLE
🏫 Add Mollenkopf Athletic Center to building table

### DIFF
--- a/src/Scraper/MyPurdueScraper.cs
+++ b/src/Scraper/MyPurdueScraper.cs
@@ -638,6 +638,11 @@ namespace PurdueIo.Scraper
 
             // New as of term 202520
             { "Hall of Data Science and AI", "DSAI" },
+
+            // New as of term 202610
+            // short code found on https://www.campus-maps.com/purdue-university/moll-mollenkopf-athletic-center/
+            // seems legit.
+            { "Mollenkopf Athletic Center", "MOLL" },
         };
 
         public (string buildingName, string buildingShortCode, string room)? ParseLocationDetails(


### PR DESCRIPTION
Sync of `202610` term was failing due to a missing building `Mollenkopf Athletic Center`.

This change adds the building to the table along with the shortcode (`MOLL`).